### PR TITLE
Add link to Banned from Equestria (Daily)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ also has huge [archive of old lego flash and shockwave games](http://biomediapro
 - [Drugs and the brain](http://jellinek.nl/brain/)
 - [Frog in a blender](http://joecartoon.com/games/play/65/Frog_in_a_Blender)
 - [Ultimate Flash Sonic](https://www.newgrounds.com/portal/view/151706)
+- [Banned from Equestria (Daily)](https://pokehidden.archive.hexstream.net/banned_from_equestria_daily/game.swf.html)
 
 ## Flash and Shockwave games
 Some of these games will probably disappear if Flash gets killed:


### PR DESCRIPTION
[Banned from Equestria (Daily)](https://pokehidden.archive.hexstream.net/banned_from_equestria_daily/game.swf.html) is, to my admittedly limited knowledge, probably one of the most extensive and intricate **NSFW** Flash games ever.

This game is basically the only reason I care about Flash...

(edit: I would normally have tagged the entry `NSFW`, but I'm guessing `Frog in a blender` is probably `NSFW`, and it's not tagged as such, I don't have time to review the other entries to see to what extent they are or are not NSFW...)