### PR TITLE
Change Homestuck BETA to Homestuck, update URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Feel free to add other interactive art projects, websites, games and experiments
 - [Metal Gear Awesome](http://metalgear.wikia.com/wiki/Metal_Gear_Awesome)
 - [Homestar Runner](http://homestarrunner.com)
 - [Tales for the L33T: Romeo and Juliet, by Chris Coutts.](http://www.albinoblacksheep.com/flash/romjul)
-- [Homestuck BETA](http://www.mspaintadventures.com/?s=5)
+- [Homestuck](https://homestuck.com/story)
 - [I Wish I Were the Moon](http://www.kongregate.com/games/danielben/i-wish-i-were-the-moon)
 - [Cursor\*10](http://www.flashgamesplayer.com/online/Cursor-10.html)
 - [Clock2D.com](https://www.clock2d.com/) - Alarm clock radio with themes, fullscreen, countdown, and sharing features.


### PR DESCRIPTION
Homestuck moved to homestuck.com in April 2018. Also, while the non-beta comic is not entirely made in Flash, Flash is still a core part of it. You'd be missing a very large part of the experience if you skipped all content made in Flash, and the comic wouldn't even be readable on the old site due to some links being inside what were formerly Flash movies.